### PR TITLE
extend keywords with abbreviations

### DIFF
--- a/code/web/data/abbreviations.tsv
+++ b/code/web/data/abbreviations.tsv
@@ -1,16 +1,21 @@
 abbreviation	value
-NER	named entity recognition
-NEL	named entity linking
+ASR	automatic speech recognition
+CNN	convolutional neural network
+DL	deep learning
 IE	information extraction
 IR	information retrieval
-QA	question answering
-SMT	statistic machine translation
-NMT	neural machine translation
-NLU	natural language understanding
+NEL	named entity linking
+NER	named entity recognition
 NLI	natural language inference
+NLP	natural language processing
+NLU	natural language understanding
 ML	machine learning
-ASR	automatic speech recognition
-TTS	text to speech
+MT	machine translation
+NMT	neural machine translation
 POS	part of speech
+QA	question answering
 RNN	reсurrent neural network
-CNN	convolutional neural network
+SMT	statistical machine translation
+TTS	text to speech
+АОТ	автоматическая обработка языка
+МО	машинное обучение

--- a/code/web/data/abbreviations.tsv
+++ b/code/web/data/abbreviations.tsv
@@ -1,0 +1,16 @@
+abbreviation	value
+NER	named entity recognition
+NEL	named entity linking
+IE	information extraction
+IR	information retrieval
+QA	question answering
+SMT	statistic machine translation
+NMT	neural machine translation
+NLU	natural language understanding
+NLI	natural language inference
+ML	machine learning
+ASR	automatic speech recognition
+TTS	text to speech
+POS	part of speech
+RNN	reсurrent neural network
+CNN	convolutional neural network

--- a/code/web/rusnlp.cfg
+++ b/code/web/rusnlp.cfg
@@ -4,6 +4,7 @@ root = ./
 database = rus_nlp_20201124.db
 database_meta = metadata.json
 nlpub_file = nlpub.tsv
+abb_file = abbreviations.tsv
 l10n = strings.tsv
 
 [Sockets]


### PR DESCRIPTION
If the query contains an abbreviation, the keywords are extended with the full name